### PR TITLE
feat: port over the dolphin junk seed recovery code

### DIFF
--- a/nod/src/disc/writer.rs
+++ b/nod/src/disc/writer.rs
@@ -245,6 +245,12 @@ pub(crate) fn check_block(
         let partition_start = partition.data_start_sector as u64 * SECTOR_SIZE as u64;
         let partition_offset =
             ((input_position - partition_start) / SECTOR_SIZE as u64) * SECTOR_DATA_SIZE as u64;
+        // Junk data within a partition is seeded from the partition's own disc header, which is
+        // also what junk regeneration uses at read time. It usually matches the outer disc
+        // header, but nothing guarantees that.
+        let partition_header = partition.disc_header();
+        let disc_id = *array_ref![partition_header.game_id, 0, 4];
+        let disc_num = partition_header.disc_num;
         if sector_data_iter(block).enumerate().all(|(i, sector_data)| {
             let sector_offset = partition_offset + i as u64 * SECTOR_DATA_SIZE as u64;
             lfg.check_sector_chunked(sector_data, disc_id, disc_num, sector_offset)
@@ -266,4 +272,80 @@ pub(crate) fn check_block(
 #[inline]
 fn sector_data_iter(buf: &[u8]) -> impl Iterator<Item = &[u8; SECTOR_DATA_SIZE]> {
     buf.chunks_exact(SECTOR_SIZE).map(|chunk| (&chunk[HASHES_SIZE..]).try_into().unwrap())
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use zerocopy::FromZeros;
+
+    use super::*;
+    use crate::{
+        common::PartitionKind,
+        disc::{BOOT_SIZE, wii::WiiPartitionHeader},
+        util::lfg::LaggedFibonacci,
+    };
+
+    const PARTITION_ID: [u8; 4] = *b"GKQJ";
+    const OUTER_ID: [u8; 4] = *b"GKQE";
+
+    fn partition_info() -> PartitionInfo {
+        let mut raw_boot = [0u8; BOOT_SIZE];
+        raw_boot[..4].copy_from_slice(&PARTITION_ID);
+        raw_boot[4..6].copy_from_slice(b"01");
+        PartitionInfo {
+            index: 0,
+            kind: PartitionKind::Data,
+            start_sector: 0,
+            data_start_sector: 0,
+            data_end_sector: 16,
+            key: [0u8; 16],
+            header: Arc::new(WiiPartitionHeader::new_zeroed()),
+            has_encryption: false,
+            has_hashes: true,
+            raw_boot: Arc::new(raw_boot),
+            raw_fst: None,
+        }
+    }
+
+    fn junk_sector(disc_id: [u8; 4]) -> Vec<u8> {
+        let mut buf = vec![0u8; SECTOR_SIZE];
+        let mut lfg = LaggedFibonacci::default();
+        lfg.fill_sector_chunked(&mut buf[HASHES_SIZE..], disc_id, 0, 0);
+        buf
+    }
+
+    fn run_check_block(buf: &[u8], partition: &PartitionInfo) -> CheckBlockResult {
+        let mut decrypted = vec![0u8; buf.len()];
+        check_block(
+            buf,
+            &mut decrypted,
+            0,
+            std::slice::from_ref(partition),
+            &mut LaggedFibonacci::default(),
+            OUTER_ID,
+            0,
+            false,
+        )
+        .unwrap()
+    }
+
+    /// Junk inside a partition is seeded from the partition's own disc header, which may differ
+    /// from the outer disc header (and is what read-time regeneration uses).
+    #[test]
+    fn check_block_seeds_partition_junk_from_partition_header() {
+        let partition = partition_info();
+        let result = run_check_block(&junk_sector(PARTITION_ID), &partition);
+        assert!(matches!(result, CheckBlockResult::Junk));
+    }
+
+    /// Junk generated from the outer disc header's ID must NOT be detected inside a partition
+    /// with a different ID: read-time regeneration would produce different bytes.
+    #[test]
+    fn check_block_rejects_outer_header_junk_in_partition() {
+        let partition = partition_info();
+        let result = run_check_block(&junk_sector(OUTER_ID), &partition);
+        assert!(matches!(result, CheckBlockResult::Normal));
+    }
 }

--- a/nod/src/io/wia.rs
+++ b/nod/src/io/wia.rs
@@ -1083,6 +1083,17 @@ struct BlockMetaWIA {
     data_hash: u64,
 }
 
+/// How the LFG seed for a packed junk area is obtained.
+enum JunkSeed {
+    /// All-zero data, packed as an all-zeroes seed.
+    Zeroed,
+    /// Standard junk: seed derived from the disc ID, disc number, and sector.
+    Sector(u32),
+    /// Seed recovered from the junk data itself (e.g. when the disc header's game ID no longer
+    /// matches the ID the junk was generated from).
+    Recovered([u32; SEED_SIZE]),
+}
+
 #[derive(Clone)]
 struct JunkInfo {
     start_sector: u32,
@@ -1298,7 +1309,7 @@ impl BlockProcessorWIA {
                     // will likely handle this better.
                     if self.compressor.kind == Compression::None && zeroes > SEED_SIZE_BYTES + 4 {
                         debug!("Packing {} zero bytes in group {}", zeroes, info.index);
-                        junk_areas.push((data_offset, u32::MAX, zeroes));
+                        junk_areas.push((data_offset, JunkSeed::Zeroed, zeroes));
                     }
 
                     offset += zeroes as u64;
@@ -1317,9 +1328,25 @@ impl BlockProcessorWIA {
                 .count();
             if num_match > SEED_SIZE_BYTES + 4 {
                 debug!("Matched {} junk bytes at offset {:#X}", num_match, offset);
-                junk_areas.push((data_offset, sector, num_match));
+                junk_areas.push((data_offset, JunkSeed::Sector(sector), num_match));
                 offset += num_match as u64;
                 data_offset += num_match;
+            } else {
+                // The disc-ID-derived seed didn't match (e.g. the game ID was modified by a
+                // patch after the junk was generated). Try to recover the seed from the data
+                // itself, like Dolphin does.
+                let mut seed = [0u32; SEED_SIZE];
+                let num_match = self.lfg.recover_seed(
+                    &data[data_offset..data_offset + len],
+                    sector_offset,
+                    &mut seed,
+                );
+                if num_match > SEED_SIZE_BYTES + 4 {
+                    debug!("Recovered junk seed for {} bytes at offset {:#X}", num_match, offset);
+                    junk_areas.push((data_offset, JunkSeed::Recovered(seed), num_match));
+                    offset += num_match as u64;
+                    data_offset += num_match;
+                }
             }
 
             if offset < sector_end {
@@ -1355,18 +1382,26 @@ impl BlockProcessorWIA {
             out: &mut [u8],
             offset: usize,
             len: usize,
-            sector: u32,
+            seed: &JunkSeed,
             junk_info: &JunkInfo,
         ) {
             let mut seed_out = [0u32; SEED_SIZE];
-            // We use u32::MAX as a marker for zeroed data (LFG seed all zeroes)
-            if sector != u32::MAX {
-                LaggedFibonacci::generate_seed_be(
-                    &mut seed_out,
-                    junk_info.disc_id,
-                    junk_info.disc_num,
-                    sector,
-                );
+            match seed {
+                // Zeroed data is packed as an all-zeroes LFG seed
+                JunkSeed::Zeroed => {}
+                JunkSeed::Sector(sector) => {
+                    LaggedFibonacci::generate_seed_be(
+                        &mut seed_out,
+                        junk_info.disc_id,
+                        junk_info.disc_num,
+                        *sector,
+                    );
+                }
+                JunkSeed::Recovered(seed) => {
+                    for (out, x) in seed_out.iter_mut().zip(seed) {
+                        *out = x.to_be();
+                    }
+                }
             }
             *array_ref_mut![out, offset, 4] = (len as u32 | COMPRESSED_BIT).to_be_bytes();
             array_ref_mut![out, offset + 4, SEED_SIZE_BYTES].copy_from_slice(seed_out.as_bytes());
@@ -1388,7 +1423,8 @@ impl BlockProcessorWIA {
             let mut packed_data = BytesMut::zeroed(packed_data_len);
             let mut packed_data_offset = 0;
             last_data_offset = 0;
-            for &(data_offset, sector, len) in &junk_areas {
+            for (data_offset, seed, len) in &junk_areas {
+                let (data_offset, len) = (*data_offset, *len);
                 if data_offset > last_data_offset {
                     let len = data_offset - last_data_offset;
                     write_raw_data(
@@ -1400,7 +1436,7 @@ impl BlockProcessorWIA {
                     );
                     packed_data_offset += 4 + len;
                 }
-                write_junk_data(packed_data.as_mut(), packed_data_offset, len, sector, junk_info);
+                write_junk_data(packed_data.as_mut(), packed_data_offset, len, seed, junk_info);
                 packed_data_offset += 4 + SEED_SIZE_BYTES;
                 last_data_offset = data_offset + len;
             }

--- a/nod/src/util/lfg.rs
+++ b/nod/src/util/lfg.rs
@@ -147,6 +147,137 @@ impl LaggedFibonacci {
         }
     }
 
+    /// Reverses the LFG by one step. Exact inverse of [`Self::forward`].
+    #[inline(never)]
+    fn backward(&mut self) {
+        for i in (LFG_J..LFG_K).rev() {
+            self.buffer[i] ^= self.buffer[i - LFG_J];
+        }
+        for i in (0..LFG_J).rev() {
+            self.buffer[i] ^= self.buffer[i + LFG_K - LFG_J];
+        }
+    }
+
+    /// Reverses the LFG by one step, only for words in `start_word..end_word`.
+    fn backward_range(&mut self, start_word: usize, end_word: usize) {
+        let loop_end = LFG_J.max(start_word);
+        let mut i = end_word.min(LFG_K);
+        while i > loop_end {
+            i -= 1;
+            self.buffer[i] ^= self.buffer[i - LFG_J];
+        }
+        let mut i = end_word.min(LFG_J);
+        while i > start_word {
+            i -= 1;
+            self.buffer[i] ^= self.buffer[i + LFG_K - LFG_J];
+        }
+    }
+
+    /// Same as [`Self::init`], but verifies that the expanded state is consistent with the
+    /// existing buffer contents (which were reconstructed from junk data). Returns false if the
+    /// buffer could not have been produced by any seed.
+    fn init_check_existing(&mut self) -> bool {
+        for i in SEED_SIZE..LFG_K {
+            let calculated = (self.buffer[i - SEED_SIZE] << 23)
+                ^ (self.buffer[i - SEED_SIZE + 1] >> 9)
+                ^ self.buffer[i - 1];
+            // Bits 16-17 of each word are not recoverable from the output data, so they're
+            // excluded from the comparison.
+            let actual = (self.buffer[i] & 0xFF00FFFF) | ((self.buffer[i] << 2) & 0x00FC0000);
+            if calculated & 0xFFFCFFFF != actual {
+                return false;
+            }
+            self.buffer[i] = calculated;
+        }
+        for x in self.buffer.iter_mut() {
+            *x = ((*x & 0xFF00FFFF) | ((*x >> 2) & 0x00FF0000)).to_be();
+        }
+        for _ in 0..4 {
+            self.forward();
+        }
+        true
+    }
+
+    /// Reconstructs the seed from a fully-populated output buffer by running the generator
+    /// backward. On success, writes the recovered seed (same domain as [`Self::generate_seed`])
+    /// to `seed_out` and leaves the generator initialized. Returns false if the buffer contents
+    /// are not valid LFG output.
+    fn reinitialize(&mut self, seed_out: &mut [u32; SEED_SIZE]) -> bool {
+        for _ in 0..4 {
+            self.backward();
+        }
+        for x in self.buffer.iter_mut() {
+            *x = u32::from_be(*x);
+        }
+        // Reconstruct the bits which are missing due to the output code shifting by 18 instead
+        // of 16. Bits 16-17 of the first word are not recoverable, but they don't affect the
+        // observable output.
+        for i in 0..SEED_SIZE {
+            self.buffer[i] = (self.buffer[i] & 0xFF00FFFF)
+                | ((self.buffer[i] << 2) & 0x00FC0000)
+                | (((self.buffer[i + 16] ^ self.buffer[i + 15]) << 9) & 0x00030000);
+        }
+        seed_out.copy_from_slice(&self.buffer[..SEED_SIZE]);
+        self.init_check_existing()
+    }
+
+    /// Attempts to recover the LFG seed directly from junk data, without knowing the disc ID it
+    /// was generated from. `data` must start at `stream_offset` bytes into the junk stream (i.e.
+    /// the offset within the sector, since the stream reseeds every sector). Requires at least
+    /// [`LFG_K_BYTES`] (plus up to 3 alignment bytes) of contiguous junk.
+    ///
+    /// On success, writes the recovered seed (same domain as [`Self::generate_seed`]) to
+    /// `seed_out` and returns the number of bytes from the start of `data` the seed reproduces.
+    /// Returns 0 if no seed could be recovered.
+    ///
+    /// Reference: `LaggedFibonacciGenerator::GetSeed` in Dolphin (CC0-1.0).
+    #[instrument(name = "LaggedFibonacci::recover_seed", skip_all)]
+    pub fn recover_seed(
+        &mut self,
+        data: &[u8],
+        stream_offset: usize,
+        seed_out: &mut [u32; SEED_SIZE],
+    ) -> usize {
+        // Only whole u32 words (relative to the junk stream) are used to regenerate the seed.
+        let bytes_to_skip = stream_offset.next_multiple_of(4) - stream_offset;
+        if data.len() < bytes_to_skip + LFG_K_BYTES {
+            return 0;
+        }
+        let word_offset = (stream_offset + bytes_to_skip) / 4;
+        let word_offset_mod_k = word_offset % LFG_K;
+        let word_offset_div_k = word_offset / LFG_K;
+
+        for (i, chunk) in
+            data[bytes_to_skip..bytes_to_skip + LFG_K_BYTES].chunks_exact(4).enumerate()
+        {
+            let word = u32::from_be_bytes(chunk.try_into().unwrap());
+            // If the data doesn't look like something we can regenerate, return early.
+            if word & 0x00C00000 != (word >> 2) & 0x00C00000 {
+                return 0;
+            }
+            self.buffer[(word_offset_mod_k + i) % LFG_K] = word.to_be();
+        }
+
+        self.backward_range(0, word_offset_mod_k);
+        for _ in 0..word_offset_div_k {
+            self.backward();
+        }
+        if !self.reinitialize(seed_out) {
+            return 0;
+        }
+
+        // Independently verify with the recovered seed through the same code path readers use,
+        // and count how many bytes it reproduces.
+        self.buffer[..SEED_SIZE].copy_from_slice(seed_out);
+        self.position = 0;
+        self.init();
+        self.skip(stream_offset);
+        let mut lfg_buf = [0u8; SECTOR_SIZE];
+        let len = data.len().min(SECTOR_SIZE - stream_offset);
+        self.fill(&mut lfg_buf[..len]);
+        data[..len].iter().zip(&lfg_buf[..len]).take_while(|(a, b)| a == b).count()
+    }
+
     /// Skips `n` bytes of junk data.
     pub fn skip(&mut self, n: usize) {
         self.position += n;
@@ -343,6 +474,54 @@ mod tests {
             0xA2, 0x0E, 0xDC, 0x0D, 0x59, 0xC0, 0x02, 0x98, 0xA5, 0x00, 0x39, 0x5B, 0x68, 0xA6,
             0x5D, 0x53, 0x2D, 0xB6
         ]);
+    }
+
+    #[test]
+    fn test_recover_seed_aligned() {
+        let mut src = LaggedFibonacci::default();
+        let mut data = vec![0u8; SECTOR_SIZE];
+        src.fill_sector_chunked(&mut data, [0x47, 0x4B, 0x51, 0x4A], 0, 3 * SECTOR_SIZE as u64);
+        let mut seed = [0u32; SEED_SIZE];
+        let mut lfg = LaggedFibonacci::default();
+        let matched = lfg.recover_seed(&data, 0, &mut seed);
+        assert_eq!(matched, SECTOR_SIZE);
+        // The recovered seed must reproduce the junk stream through the reader code path.
+        let mut check = LaggedFibonacci::default();
+        check.buffer[..SEED_SIZE].copy_from_slice(&seed);
+        check.init();
+        let mut buf = vec![0u8; SECTOR_SIZE];
+        check.fill(&mut buf);
+        assert_eq!(buf, data);
+    }
+
+    #[test]
+    fn test_recover_seed_unaligned_offset() {
+        let mut src = LaggedFibonacci::default();
+        let mut sector = vec![0u8; SECTOR_SIZE];
+        src.fill_sector_chunked(&mut sector, [0x52, 0x45, 0x4C, 0x53], 1, 7 * SECTOR_SIZE as u64);
+        let off = 0x1235;
+        let mut seed = [0u32; SEED_SIZE];
+        let mut lfg = LaggedFibonacci::default();
+        let matched = lfg.recover_seed(&sector[off..], off, &mut seed);
+        assert_eq!(matched, SECTOR_SIZE - off);
+    }
+
+    #[test]
+    fn test_recover_seed_rejects_non_junk() {
+        let data = vec![0xA5u8; SECTOR_SIZE];
+        let mut seed = [0u32; SEED_SIZE];
+        let mut lfg = LaggedFibonacci::default();
+        assert_eq!(lfg.recover_seed(&data, 0, &mut seed), 0);
+    }
+
+    #[test]
+    fn test_recover_seed_too_short() {
+        let mut src = LaggedFibonacci::default();
+        let mut data = vec![0u8; LFG_K_BYTES - 4];
+        src.fill_sector_chunked(&mut data, [0x47, 0x4B, 0x51, 0x4A], 0, 0);
+        let mut seed = [0u32; SEED_SIZE];
+        let mut lfg = LaggedFibonacci::default();
+        assert_eq!(lfg.recover_seed(&data, 0, &mut seed), 0);
     }
 
     #[test]


### PR DESCRIPTION
👋🏻 Hi again, most of this code is based on what dolphin does. I ran into an issue using nod where I was getting some strand compression results on a rom hack ([Kururin Squash Translation](https://github.com/DOL-Translations/kururin-squash)). Basically after the rom hack was applied the rom would not compress at all. narrowed it down to the junk data detection recovery. 

For reference:
The LFG seed-recovery implementation is substantially ported to Rust from Dolphin’s LaggedFibonacciGenerator::GetSeed
  (https://github.com/dolphin-emu/dolphin/blob/master/Source/Core/DiscIO/LaggedFibonacciGenerator.cpp), originally introduced by JosJuice in
  [dolphin-emu/dolphin@4b74993](https://github.com/dolphin-emu/dolphin/commit/4b74993374348185c304a68b2b159f3cdbb89360) (https://github.com/dolphin-emu/dolphin/commit/4b74993374348185c304a68b2b159f3cdbb89360). That source is licensed under
  CC0-1.0