### PR TITLE
fix: include the io source when displaying Error::Io

### DIFF
--- a/nod/src/lib.rs
+++ b/nod/src/lib.rs
@@ -173,7 +173,7 @@ pub enum Error {
     #[error("disc format error: {0}")]
     DiscFormat(String),
     /// A general I/O error.
-    #[error("{0}")]
+    #[error("{0}: {1}")]
     Io(String, #[source] std::io::Error),
     /// An unknown error.
     #[error("error: {0}")]


### PR DESCRIPTION
When something breaks deep inside nod you tend to get a message like:

```
Failed to process block 1
```

That tells you where it broke but not why. The why is already sitting in the error, it just never gets printed.

`Error::Io` holds two things: a bit of context, and the real `io::Error` underneath. The `Display` impl is `"{0}"`, so it prints the context and throws the useful half away. You only get it back if whatever catches the error walks the source chain itself, and most callers just print the error.

Printing both gives you:

```
Failed to process block 1: Reading block for sector 0: Bad file descriptor (os error 8)
```

which actually tells you what happened.

I ran into this chasing a threading bug in a project that embeds nod. "Failed to process block 1" was the only thing I had, and it was a dead end. I patched this one line locally to see what was underneath, and the cause was obvious immediately.

It's only the format string. No types change, no behaviour changes. The nesting reads fine because `io_context` already wraps an `Error::Io`, so each layer of context just adds one more piece to the message.

`cargo check --workspace` is clean.
