### PR TITLE
fix: read the GameCube FST so junk detection can find file ends

### DIFF
--- a/nod/src/disc/reader.rs
+++ b/nod/src/disc/reader.rs
@@ -133,7 +133,12 @@ impl DiscReader {
 
             DiscReaderData::Wii { partitions, alt_partitions, region }
         } else if disc_header.is_gamecube() {
-            DiscReaderData::GameCube { raw_fst: None }
+            let boot_header = BootHeader::ref_from_bytes(&raw_boot[BB2_OFFSET..])
+                .expect("Invalid boot header alignment");
+            let raw_fst = read_fst(reader.as_mut(), boot_header, false)
+                .inspect_err(|e| warn!("Failed to read GameCube FST: {}", e))
+                .ok();
+            DiscReaderData::GameCube { raw_fst }
         } else {
             return Err(Error::DiscFormat("Invalid disc header".to_string()));
         };


### PR DESCRIPTION
Noticed while benchmarking against dolphin-tool that one GameCube disc came out 8.4% bigger from nod at the same codec/level/block size. Turns out `DiscReader::new` never fills in `raw_fst` for GameCube discs, so junk detection has no file ends to work with — any sector that starts with file data gets its junk tail compressed as real data instead of packed as a seed.

This reads the FST the same way the Wii path already does. That disc goes from 118 MB to 108.4 MB (dolphin-tool gets 108.9 MB), and the RVZ still converts back to a SHA-1-identical ISO.

`cargo test --workspace` passes, `cargo +nightly fmt` is clean.